### PR TITLE
FIX: Allow pre-release versions of SS4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"composer/installers": "*",
-		"silverstripe/framework": "^4"
+		"silverstripe/framework": "^4@dev"
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
Since SS4 has not yet been released, and this module is used to test
pre-release versions of SS4, we need to have @dev on the requirement
to make it as flexible as possible.

As a general rule, modules that plug *into* SS4 rather than making *use*
of it should have @dev on the end of their dependencies.