### PR TITLE
Fixed DatetimeField API usage

### DIFF
--- a/code/TestSessionController.php
+++ b/code/TestSessionController.php
@@ -255,13 +255,6 @@ class TestSessionController extends Controller
             new HiddenField('flush', null, 1)
         );
         $textfield->setAttribute('placeholder', 'Example: framework/tests/security/MemberTest.yml');
-        $datetimeField->getDateField()
-            ->setConfig('dateformat', 'yyyy-MM-dd')
-            ->setConfig('showcalendar', true)
-            ->setAttribute('placeholder', 'Date (yyyy-MM-dd)');
-        $datetimeField->getTimeField()
-            ->setConfig('timeformat', 'HH:mm:ss')
-            ->setAttribute('placeholder', 'Time (HH:mm:ss)');
         $datetimeField->setValue((isset($testState->datetime) ? $testState->datetime : null));
 
         $this->extend('updateBaseFields', $fields);


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/6626

Haven't actually been able to verify this since `dev/testsession` breaks with an inexplicable "server error" here (even in dev mode), but the fix itself is pretty straightforward.