### PR TITLE
FIX Be less opinionated about test DB name

### DIFF
--- a/src/TestSessionEnvironment.php
+++ b/src/TestSessionEnvironment.php
@@ -245,7 +245,7 @@ class TestSessionEnvironment
 
                 // Set existing one, assumes it already has been created
                 $prefix = defined('SS_DATABASE_PREFIX') ? SS_DATABASE_PREFIX : 'ss_';
-                $pattern = strtolower(sprintf('#^%stmpdb\d{7}#', $prefix));
+                $pattern = strtolower(sprintf('#^%stmpdb.*#', preg_quote($prefix, '#')));
                 if (!preg_match($pattern, $dbName)) {
                     throw new InvalidArgumentException("Invalid database name format");
                 }


### PR DESCRIPTION
I'm not really sure why we even have this check because the call a few lines above asks `SapphireTest` to give us the DB Name and we should have faith that the DB name it supplies is acceptable..

I'd advocate removing this check completely