### PR TITLE
Fix TestSessionState and TestSessionEnvironment

### DIFF
--- a/src/TestSessionEnvironment.php
+++ b/src/TestSessionEnvironment.php
@@ -573,24 +573,22 @@ class TestSessionEnvironment
      */
     public function waitForPendingRequests($await = 700, $timeout = 10000)
     {
-        $now = static function () {
-            return microtime(true) * 10000;
-        };
-
-        $timeout = $now() + $timeout;
+        $timeout = TestSessionState::microtime() + $timeout;
         $interval = max(300, $await);
+
         do {
+            $now = TestSessionState::microtime();
+
+            if ($timeout < $now) {
+                return false;
+            }
+
             $model = TestSessionState::get()->byID(1);
 
             $pendingRequests = $model->PendingRequests > 0;
-            $lastRequestAwait = ($model->LastResponseTimestamp + $await) > $now();
+            $lastRequestAwait = ($model->LastResponseTimestamp + $await) > $now;
 
             $pending = $pendingRequests || $lastRequestAwait;
-
-            if ($timeout < $now()) {
-                // timed out
-                return false;
-            }
         } while ($pending && (usleep($interval * 1000) || true));
 
         return true;

--- a/src/TestSessionState.php
+++ b/src/TestSessionState.php
@@ -53,8 +53,18 @@ class TestSessionState extends DataObject
         $update = SQLUpdate::create(sprintf('"%s"', $schema->tableName(self::class)))
                 ->addWhere(['ID' => 1])
                 ->assignSQL('"PendingRequests"', '"PendingRequests" - 1')
-                ->assign('"LastResponseTimestamp"', microtime(true) * 10000);
+                ->assign('"LastResponseTimestamp"', self::microtime());
 
         $update->execute();
+    }
+
+    /**
+     * Returns unix timestamp in milliseconds
+     *
+     * @return float milliseconds since 1970
+     */
+    public static function microtime()
+    {
+        return round(microtime(true) * 1000);
     }
 }


### PR DESCRIPTION
Fixing a bug that makes it only wait for pending requests, but
not for some time after the last response.
`$await` used to be in microseconds, but timestamps in (microseconds * 10), so that `$lastRequestAwait` was always `false`.