### PR TITLE
Connect to test database on session load

### DIFF
--- a/src/TestSessionHTTPMiddleware.php
+++ b/src/TestSessionHTTPMiddleware.php
@@ -71,6 +71,9 @@ class TestSessionHTTPMiddleware implements HTTPMiddleware
             Email::config()->set("send_all_emails_to", null);
         }
 
+        // Connect to the test session database
+        $this->testSessionEnvironment->connectToDatabase();
+
         // Allows inclusion of a PHP file, usually with procedural commands
         // to set up required test state. The file can be generated
         // through {@link TestSessionStubCodeWriter}, and the session state
@@ -79,9 +82,6 @@ class TestSessionHTTPMiddleware implements HTTPMiddleware
         if (isset($testState->stubfile)) {
             $file = $testState->stubfile;
             if (!Director::isLive() && $file && file_exists($file)) {
-                // Connect to the database so the included code can interact with it
-                $this->testSessionEnvironment->connectToDatabase();
-
                 include_once($file);
             }
         }


### PR DESCRIPTION
Currently when loading the test state a connection to the temp DB is only made if there is a stub file. 
This means when using a fixture to create DB state, there is no connection created and subsequent requests to content in a fixture don't work. 

eg with fixture:
```yaml
SiteTree:
  page1:
    Title: Testing 123
    URLSegment: init

SiteTree_Live:
  page1:
    ID: =>SiteTree.page1
    Title: Testing 123
    URLSegment: init
    Content: Testing 1234
```
and then visiting `/dev/testsession/start?fixture=pathtoabovefixture.yaml`
i would expect to get a page at `/init` but it returns a 404 as the connection remains to the original db.

This change attempts to connect to the temp db on load as I couldn't think of a reason why you wouldn't want to do that.