### PR TITLE
Skip Temp DB creation if state has no database prop

### DIFF
--- a/src/TestSessionEnvironment.php
+++ b/src/TestSessionEnvironment.php
@@ -288,6 +288,7 @@ class TestSessionEnvironment
 
         // Database
         if (!$this->isRunningTests()) {
+            $dbCreate = isset($state->createDatabase) ? (bool) $state->createDatabase : false;
             $dbName = (isset($state->database)) ? $state->database : null;
 
             if ($dbName) {
@@ -296,7 +297,7 @@ class TestSessionEnvironment
                 $dbExists = false;
             }
 
-            if (!$dbExists) {
+            if (!$dbExists && $dbCreate) {
                 // Create a new one with a randomized name
                 $tempDB = new TempDatabase();
                 $dbName = $tempDB->build();
@@ -310,7 +311,6 @@ class TestSessionEnvironment
                     throw new InvalidArgumentException("Invalid database name format");
                 }
 
-                $this->oldDatabaseName = $databaseConfig['database'];
                 $databaseConfig['database'] = $dbName; // Instead of calling DB::set_alternative_db_name();
 
                 // Connect to the new database, overwriting the old DB connection (if any)


### PR DESCRIPTION
I found that when calling `dev/testsession/end` a second Temp DB is created and not removed. 

in `end()` the session state is cleared, test file removed and the temp DB is removed. Then, the middleware calls `restoreTestState` and subsequently `applyState` with the now empty state. This results in the creation of a new, extraneous, Temp DB.

Rather than always creating a new DB I've changed it to only creating one if the db in `$state->database` does not exist and there the 'createDatabase' option has been selected in the start form.

I also removed a redundant call to save the old db name (it is already done further up in the method).