### PR TITLE
Prevent re-creating session file on end

### DIFF
--- a/src/TestSessionController.php
+++ b/src/TestSessionController.php
@@ -311,7 +311,7 @@ class TestSessionController extends Controller
 
         $this->extend('onBeforeClear');
 
-        $tempDB = new TempDatabase();
+        $tempDB = TempDatabase::create();
         if ($tempDB->isUsed()) {
             $tempDB->clearAllData();
         }

--- a/tests/stubs/teststub.php
+++ b/tests/stubs/teststub.php
@@ -1,0 +1,3 @@
+<?php
+
+define('TESTSESSION_STUBFILE', false);

--- a/tests/unit/TestSessionControllerTest.php
+++ b/tests/unit/TestSessionControllerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace SilverStripe\TestSession\Tests\Unit;
+
+use DateTime;
+use LogicException;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\Email\Mailer;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Manifest\ModuleLoader;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\TestSession\TestSessionController;
+use SilverStripe\TestSession\TestSessionEnvironment;
+use SilverStripe\TestSession\TestSessionHTTPMiddleware;
+use stdClass;
+use SilverStripe\ORM\Connect\TempDatabase;
+use SilverStripe\Core\Config\Config;
+
+class TestSessionControllerTest extends SapphireTest
+{
+    /**
+     * @var TestSessionEnvironment|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $testSessionEnvironment;
+
+    protected $usesDatabase = true;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Injector::inst()->unregisterNamedObject(TestSessionEnvironment::class);
+        Injector::inst()->registerService(
+            $this->createMock(TestSessionEnvironment::class),
+            TestSessionEnvironment::class
+        );
+        $this->testSessionEnvironment = TestSessionEnvironment::singleton();
+    }
+
+    public function testIndex()
+    {
+        $controller = new TestSessionController();
+        $this->assertContains('Start a new test session', (string) $controller->index());
+
+        $env = $this->testSessionEnvironment;
+        $env->method('isRunningTests')
+            ->willReturn(true);
+
+        $state = new stdClass();
+        $state->showme = 'test';
+        $env->method('getState')
+            ->willReturn($state);
+
+        $html = (string) $controller->index();
+        $this->assertContains('Test session in progress.', $html);
+        $this->assertContains('showme:', $html);
+    }
+
+    public function testStartNonGlobalImport()
+    {
+        DBDatetime::set_mock_now(1552525373);
+        $params = [
+            'datetime' => [
+                'date' => DBDatetime::now()->Date(),
+            ],
+            'importDatabasePath' => '/somepath',
+            'importDatabaseFilename' => 'bigOldb.sql',
+            'requireDefaultRecords' => '1',
+            'fixture' => 'fixture.yml',
+        ];
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $env = $this->testSessionEnvironment;
+            $state = new stdClass();
+
+            $env->method('getState')
+                ->willReturn($state);
+
+            $env->expects($this->once())
+                ->method('startTestSession')
+                ->with(
+                    [
+                        'datetime' => 'Mar 14, 2019 00:00:00',
+                        'importDatabasePath' => '/somepath',
+                        'importDatabaseFilename' => 'bigOldb.sql',
+                        'requireDefaultRecords' => '1',
+                        'fixture' => 'fixture.yml',
+                    ],
+                    $this->isType('string')
+                );
+
+            // cannot do an import and default records
+            $env->expects($this->never())
+                ->method('requireDefaultRecords');
+
+            $env->expects($this->once())
+                ->method('loadFixtureIntoDb')
+                ->with('fixture.yml');
+
+            $html = (string) $controller->start();
+            $this->assertContains('Test session in progress.', $html);
+
+            $this->assertNotNull($request->getSession()->get('TestSessionId'));
+        }, 'dev/testsession/start', $params);
+
+        DBDatetime::clear_mock_now();
+    }
+
+    public function testStartNonGlobalDefaultRecords()
+    {
+        $params = [
+            'requireDefaultRecords' => '1',
+        ];
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $env = $this->testSessionEnvironment;
+            $state = new stdClass();
+
+            $env->method('getState')
+                ->willReturn($state);
+
+            $env->expects($this->once())
+                ->method('startTestSession')
+                ->with(
+                    [
+                        'requireDefaultRecords' => '1',
+                    ],
+                    $this->isType('string')
+                );
+
+            $env->expects($this->once())
+                ->method('requireDefaultRecords')
+                ->with();
+
+            $controller->start();
+        }, 'dev/testsession/start', $params);
+    }
+
+    public function testSetNotRunning()
+    {
+        $this->expectException(LogicException::class);
+        $params = [];
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $controller->set();
+        }, 'dev/testsession/set', $params);
+    }
+
+    public function testSetRunning()
+    {
+        DBDatetime::set_mock_now(1552525373);
+        $params = [
+            'datetime' => [
+                'date' => DBDatetime::now()->Date(),
+            ],
+        ];
+
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $env = $this->testSessionEnvironment;
+            $state = new stdClass();
+
+            $env->method('isRunningTests')
+                ->willReturn(true);
+
+            $env->method('getState')
+                ->willReturn($state);
+
+            $env->expects($this->once())
+                ->method('updateTestSession')
+                ->with(
+                    [
+                        'datetime' => 'Mar 14, 2019 00:00:00',
+                    ]
+                );
+
+            $html = (string) $controller->set();
+            $this->assertContains('Test session in progress.', $html);
+        }, 'dev/testsession/set', $params);
+
+        DBDatetime::clear_mock_now();
+    }
+
+    public function testClearNotRunning()
+    {
+        $this->expectException(LogicException::class);
+        $params = [];
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $controller->clear();
+        }, 'dev/testsession/clear', $params);
+    }
+
+    public function testClearRunning()
+    {
+
+        $params = [];
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $env = $this->testSessionEnvironment;
+            $state = new stdClass();
+
+            $env->method('isRunningTests')
+                ->willReturn(true);
+
+            $env->method('getState')
+                ->willReturn($state);
+
+            Config::nest();
+            Config::modify()->set(TempDatabase::class, 'factory', new class {
+                public function create()
+                {
+                    $mockdb = $this->createMock(TempDatabase::class);
+                    $mockdb->method('isUsed')->willReturn(true);
+                    $mockdb->expects($this->once())
+                        ->method('clearAllData');
+                    return $mockdb;
+                }
+            });
+
+            $msg = $controller->clear();
+            Config::unnest();
+            $this->assertEquals('Cleared database and test state', $msg);
+        }, 'dev/testsession/clear', $params);
+    }
+
+    public function testEndNotRunning()
+    {
+        $this->expectException(LogicException::class);
+        $params = [];
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $controller->end();
+        }, 'dev/testsession/end', $params);
+    }
+
+    public function testEndRunning()
+    {
+        $params = [];
+        Director::mockRequest(function ($request) {
+            $controller = new TestSessionController();
+            $controller->setRequest($request);
+
+            $env = $this->testSessionEnvironment;
+            $state = new stdClass();
+
+            $env->method('isRunningTests')
+                ->willReturn(true);
+
+            $env->method('getState')
+                ->willReturn($state);
+
+            $env->expects($this->once())
+                ->method('endTestSession');
+
+            $html = (string) $controller->end();
+            $this->assertContains('Test session ended', $html);
+
+            $this->assertNull($request->getSession()->get('TestSessionId'));
+        }, 'dev/testsession/end', $params);
+    }
+}

--- a/tests/unit/TestSessionEnvironmentTest.php
+++ b/tests/unit/TestSessionEnvironmentTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace SilverStripe\TestSession\Tests\Unit;
+
+use DateTime;
+use SilverStripe\BehatExtension\Utility\TestMailer;
+use SilverStripe\Control\Email\Mailer;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Manifest\ModuleLoader;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Connect\TempDatabase;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\TestSession\TestSessionEnvironment;
+use SilverStripe\TestSession\TestSessionState;
+use stdClass;
+
+class TestSessionEnvironmentTest extends SapphireTest
+{
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Injector::inst()->unregisterNamedObject(TestSessionEnvironment::class);
+        Injector::inst()->registerService(
+            new TestSessionEnvironment,
+            TestSessionEnvironment::class
+        );
+        $this->testSessionEnvironment = TestSessionEnvironment::singleton();
+    }
+
+    public function testApplyStateNoModification()
+    {
+        $state = new stdClass();
+        $state->testprop = '';
+
+        $env = new TestSessionEnvironment();
+        $afterApply = $env->applyState($state);
+
+        $this->assertSame($state, $afterApply);
+    }
+
+    public function testApplyStateDBConnect()
+    {
+        $state = new stdClass();
+        $state->testprop = '';
+
+        $env = $this->getMockBuilder(TestSessionEnvironment::class)
+            ->setMethodsExcept(['applyState'])
+            ->getMock();
+
+        $env->expects($this->once())
+            ->method('connectToDatabase');
+
+        $env->applyState($state);
+    }
+
+    public function testApplyStateDatetime()
+    {
+        $state = new stdClass();
+        $now = new DateTime();
+        $now->modify('-1 day');
+        $state->datetime = $now->format('Y-m-d H:i:s');
+
+        $env = new TestSessionEnvironment();
+        $env->applyState($state);
+        $date = new DateTime();
+        $this->assertNotEquals($date->getTimestamp(), DBDatetime::now()->getTimestamp());
+        $this->assertEquals($now->getTimestamp(), DBDatetime::now()->getTimestamp());
+
+        $state->datetime = 'invalid format';
+        $this->expectExceptionMessage('Invalid date format "invalid format", use yyyy-MM-dd HH:mm:ss');
+        $env->applyState($state);
+    }
+
+    public function testAppyStateMailer()
+    {
+
+        $state = new stdClass();
+        $state->mailer = TestMailer::class;
+        $env = new TestSessionEnvironment();
+
+        $env->applyState($state);
+
+        $mailer = Injector::inst()->get(Mailer::class);
+        $this->assertEquals(TestMailer::class, get_class($mailer));
+
+        $state->mailer = 'stdClass';
+        $this->expectExceptionMessage('Class "stdClass" is not a valid class, or subclass of Mailer');
+        $env->applyState($state);
+    }
+
+    public function testAppyStateStub()
+    {
+
+        $module = ModuleLoader::getModule('silverstripe/testsession');
+        $state = new stdClass();
+
+        $state->stubfile = $module->getPath() . DIRECTORY_SEPARATOR . 'tests/stubs/teststub.php';
+
+        $env = new TestSessionEnvironment();
+
+        $this->assertFalse(defined('TESTSESSION_STUBFILE'));
+
+        $env->applyState($state);
+
+        $this->assertTrue(defined('TESTSESSION_STUBFILE'));
+    }
+
+    public function testConnectToDatabase()
+    {
+        $env = new TestSessionEnvironment();
+        $dbExisting = DB::get_conn()->getSelectedDatabase();
+
+        $env->connectToDatabase(new stdClass);
+        $db = DB::get_conn()->getSelectedDatabase();
+        $this->assertEquals($dbExisting, $db);
+
+        $tempDB = new TempDatabase();
+        $dbName = $tempDB->build();
+
+        $state = new stdClass();
+        $state->database = $dbName;
+        $env->connectToDatabase($state);
+        $db = DB::get_conn()->getSelectedDatabase();
+        $this->assertEquals($dbName, $db);
+
+        $tempDB->kill();
+    }
+
+    public function testCreateDatabase()
+    {
+        $env = new TestSessionEnvironment();
+        $dbExisting = DB::get_conn()->getSelectedDatabase();
+
+        $state = new stdClass;
+
+        $env->createDatabase($state);
+        $db = DB::get_conn()->getSelectedDatabase();
+        $this->assertEquals($dbExisting, $db);
+
+
+        $state = new stdClass();
+        $state->createDatabase = true;
+        $env->createDatabase($state);
+        $db = DB::get_conn()->getSelectedDatabase();
+        $this->assertNotEquals($dbExisting, $db);
+
+        // check the TestSessionState object has been created
+        $stateObj = TestSessionState::get()->first();
+        $this->assertNotNull($stateObj);
+        $this->assertTrue($stateObj->exists());
+
+        $tempDB = new TempDatabase('default');
+        $tempDB->kill();
+
+        $state = new stdClass();
+        $state->database = $dbExisting;
+
+        $env->connectToDatabase($state);
+    }
+}

--- a/tests/unit/TestSessionHTTPMiddlewareTest.php
+++ b/tests/unit/TestSessionHTTPMiddlewareTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SilverStripe\TestSession\Tests\Unit;
+
+use DateTime;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\TestSession\TestSessionEnvironment;
+use SilverStripe\TestSession\TestSessionHTTPMiddleware;
+use stdClass;
+use SilverStripe\Control\Email\Mailer;
+use SilverStripe\Core\Manifest\ModuleLoader;
+
+class TestSessionHTTPMiddlewareTest extends SapphireTest
+{
+    /**
+     * @var TestSessionEnvironment
+     */
+    private $testSessionEnvironment;
+
+    protected $usesDatabase = true;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Injector::inst()->registerService(
+            $this->createMock(TestSessionEnvironment::class),
+            TestSessionEnvironment::class
+        );
+        $this->testSessionEnvironment = TestSessionEnvironment::singleton();
+    }
+
+    public function testProcessNoTestRunning()
+    {
+        $env = $this->testSessionEnvironment;
+
+        // setup expected calls on environment
+        $env->expects($this->never())
+            ->method('getState');
+
+        $env->expects($this->never())
+            ->method('applyState');
+
+        Injector::nest();
+
+        Injector::inst()->registerService(
+            $env,
+            TestSessionEnvironment::class
+        );
+
+        $middleware = new TestSessionHTTPMiddleware();
+        // Mock request
+        $session = new Session([]);
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession($session);
+        $delegate = function () {
+            // noop
+        };
+        $middleware->process($request, $delegate);
+
+        Injector::unnest();
+    }
+
+    public function testProcessTestsRunning()
+    {
+
+        $state = new stdClass();
+        $env = $this->testSessionEnvironment;
+
+        $env->method('isRunningTests')
+            ->willReturn(true);
+
+        // setup expected calls on environment
+        $env->expects($this->exactly(2))
+            ->method('getState')
+            ->willReturn($state);
+
+        $env->expects($this->once())
+            ->method('applyState');
+
+        Injector::nest();
+
+        Injector::inst()->registerService(
+            $env,
+            TestSessionEnvironment::class
+        );
+
+        $middleware = new TestSessionHTTPMiddleware();
+        // Mock request
+        $session = new Session([]);
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession($session);
+        $delegate = function () {
+            // noop
+        };
+        $middleware->process($request, $delegate);
+
+        Injector::unnest();
+    }
+}


### PR DESCRIPTION
`saveState` will re-create a session file after the test session has ended. This adds a condition to check if the test session has been cleared before writing the file. 