### PR TITLE
BUGFIX: updated route config for testsession endpoint

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,6 +1,7 @@
 ---
 Name: testsessionroutes
 ---
-SilverStripe\Control\Director:
-  rules:
-    dev/testsession: SilverStripe\TestSession\TestSessionController
+SilverStripe\Dev\DevelopmentAdmin:
+  registered_controllers:
+    testsession:
+      controller: SilverStripe\TestSession\TestSessionController


### PR DESCRIPTION
When the `dev/testsession` endpoint is accessed in a SilverStripe `4.3.3` / `CWP2.2.3` project, a `404` error is thrown.

The issue appears to be resolved when the configuration in `routes.yml` is updated to the one in this PR.