### PR TITLE
FIX: Ensure TempDatabase->build() doesn't tear down the database

### DIFF
--- a/src/TestSessionEnvironment.php
+++ b/src/TestSessionEnvironment.php
@@ -277,6 +277,9 @@ class TestSessionEnvironment
         $databaseConfig = DB::getConfig();
         if (!$dbExists && $dbCreate) {
             $this->oldDatabaseName = $databaseConfig['database'];
+            // Ensure we don't allow TempDatabase to immediately kill the newly created DB when the request finishes
+            Config::modify()->set(TempDatabase::class, 'teardown_on_exit', false);
+
             // Create a new one with a randomized name
             $tempDB = TempDatabase::create();
             $dbName = $tempDB->build();


### PR DESCRIPTION
Visiting dev/testsession in a browser and starting a test session doesn't work without this patch, because the temp database is created during `TestSessionEnvironment->createDatabase()` and then immediately deleted once the request finishes (due to the shutdown function registered in `TempDatabase->build()`.

This PR changes this functionality, so that it does not cleanup the DB upon request exit. This will lead to temp databases lying around, unless you end your testsession, which you should always do anyway (if for no other reason than you would also leave the TESTS_RUNNING.json file lying around)...

I think this is an API change, but I'm not sure how else to get around it, apart from setting it in a project's YML config, which could work, but would also affect other things (e.g. phpunit test runs that use `TempDatabase` etc)