### PR TITLE
FIX Add missing config to fix silverstipe/admin tests.

### DIFF
--- a/src/TestSessionHTTPMiddleware.php
+++ b/src/TestSessionHTTPMiddleware.php
@@ -69,6 +69,7 @@ class TestSessionHTTPMiddleware implements HTTPMiddleware
             $mailer = $testState->mailer;
             Injector::inst()->registerService(new $mailer(), Mailer::class);
             Email::config()->set("send_all_emails_to", null);
+            Email::config()->update('admin_email', 'no-reply@example.com');
         }
 
         // Connect to the test session database


### PR DESCRIPTION
Add config that is required for silverstripe/admin behat tests to pass.

## Parent issue:
- silverstripe/silverstripe-framework#10278